### PR TITLE
Amend the babel library and add translation to Russian and Ukrainian

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Activate the libraries using `\UseTblrLibrary` command.
 Use caption package to typeset tabularray tall and long tabulars captions.
 Enable this library with `\UseTblrLibrary{caption}`
 ## Babel Library
-Translate `contfoot` and `conthead` to current `babel` language. 
-Currently only supports ngerman, french and spanish translations.
+Translate `contfoot` and `conthead` to current `babel`/`polyglossia` language. 
+Currently only supports ngerman, french, spanish, russian and ukrainian translations.
 Enable this library with `\UseTblrLibrary{babel}`

--- a/tblr-extras.sty
+++ b/tblr-extras.sty
@@ -55,7 +55,13 @@
 }
 %% ----------------------------------------------------------------------
 %% TblrLibrary babel - Translate contfoot and conthead to current babel/polyglossia
-%% language. Supports: ngerman, french and spanish translations.
+%% language. Supports: ngerman, french, spanish, russian and ukrainian translations.
+\newif\if@unicode@engine
+\ifdefined\luatexversion
+	\@unicode@enginetrue
+\else\ifdefined\XeTeXrevision
+	\@unicode@enginetrue
+\fi\fi
 \NewTblrLibrary{babel}
 {%
 	\AddToHook{begindocument/before}{%
@@ -76,5 +82,24 @@
 			\DefTblrTemplate{contfoot-text}{default}{Suite à la page suivante}%
 			\DefTblrTemplate{conthead-text}{default}{(Suite)}%
 		}
+		\if@unicode@engine
+			\addto\captionsrussian{%
+				\DefTblrTemplate{contfoot-text}{default}{Продолжение на следующей странице}%
+				\DefTblrTemplate{conthead-text}{default}{(продолжение)}%
+			}
+			\addto\captionsukrainian{%
+				\DefTblrTemplate{contfoot-text}{default}{Продовження на наступній сторінці}%
+				\DefTblrTemplate{conthead-text}{default}{(продовження)}%
+			}
+		\else
+			\addto\captionsrussian{%
+				\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre\ \cyrn\cyra\ \cyrs\cyrl\cyre\cyrd\cyru\cyryu\cyrshch\cyre\cyrishrt\ \cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyre}%
+				\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre)}%
+			}
+			\addto\captionsukrainian{%
+				\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya\ \cyrn\cyra\ \cyrn\cyra\cyrs\cyrt\cyru\cyrp\cyrn\cyrii\cyrishrt\ \cyrs\cyrt\cyro\cyrr\cyrii\cyrn\cyrc\cyrii}%
+				\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya)}%
+			}
+		\fi
 	}
 }

--- a/tblr-extras.sty
+++ b/tblr-extras.sty
@@ -70,36 +70,55 @@
 				\RequirePackage{babel}
 			}
 		}
-		\addto\captionsspanish{%
-			\DefTblrTemplate{contfoot-text}{default}{Continúa en la página siguiente}%
-			\DefTblrTemplate{conthead-text}{default}{(Continuación)}%
-		}
-		\addto\captionsngerman{%
-			\DefTblrTemplate{contfoot-text}{default}{Fortsetzung auf der nächsten Seite}%
-			\DefTblrTemplate{conthead-text}{default}{(Fortsetzung)}%
-		}
-		\addto\captionsfrench{%
-			\DefTblrTemplate{contfoot-text}{default}{Suite à la page suivante}%
-			\DefTblrTemplate{conthead-text}{default}{(Suite)}%
-		}
-		\if@unicode@engine
-			\addto\captionsrussian{%
-				\DefTblrTemplate{contfoot-text}{default}{Продолжение на следующей странице}%
-				\DefTblrTemplate{conthead-text}{default}{(продолжение)}%
+		\ifdefined\captionsspanish
+			\addto\captionsspanish{%
+				\DefTblrTemplate{contfoot-text}{default}{Continúa en la página siguiente}%
+				\DefTblrTemplate{conthead-text}{default}{(Continuación)}%
 			}
-			\addto\captionsukrainian{%
-				\DefTblrTemplate{contfoot-text}{default}{Продовження на наступній сторінці}%
-				\DefTblrTemplate{conthead-text}{default}{(продовження)}%
+		\fi
+		\ifdefined\captionsngerman
+			\addto\captionsngerman{%
+				\DefTblrTemplate{contfoot-text}{default}{Fortsetzung auf der nächsten Seite}%
+				\DefTblrTemplate{conthead-text}{default}{(Fortsetzung)}%
 			}
-		\else
-			\addto\captionsrussian{%
-				\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre\ \cyrn\cyra\ \cyrs\cyrl\cyre\cyrd\cyru\cyryu\cyrshch\cyre\cyrishrt\ \cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyre}%
-				\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre)}%
+		\fi
+		\ifdefined\captionsgerman
+			\addto\captionsgerman{%
+				\DefTblrTemplate{contfoot-text}{default}{Fortsetzung auf der nächsten Seite}%
+				\DefTblrTemplate{conthead-text}{default}{(Fortsetzung)}%
 			}
-			\addto\captionsukrainian{%
-				\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya\ \cyrn\cyra\ \cyrn\cyra\cyrs\cyrt\cyru\cyrp\cyrn\cyrii\cyrishrt\ \cyrs\cyrt\cyro\cyrr\cyrii\cyrn\cyrc\cyrii}%
-				\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya)}%
+		\fi
+		\ifdefined\captionsfrench
+			\addto\captionsfrench{%
+				\DefTblrTemplate{contfoot-text}{default}{Suite à la page suivante}%
+				\DefTblrTemplate{conthead-text}{default}{(Suite)}%
 			}
+		\fi
+		\ifdefined\captionsrussian
+			\if@unicode@engine
+				\addto\captionsrussian{%
+					\DefTblrTemplate{contfoot-text}{default}{Продолжение на следующей странице}%
+					\DefTblrTemplate{conthead-text}{default}{(продолжение)}%
+				}
+			\else
+				\addto\captionsrussian{%
+					\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre\ \cyrn\cyra\ \cyrs\cyrl\cyre\cyrd\cyru\cyryu\cyrshch\cyre\cyrishrt\ \cyrs\cyrt\cyrr\cyra\cyrn\cyri\cyrc\cyre}%
+					\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrl\cyrzh\cyre\cyrn\cyri\cyre)}%
+				}
+			\fi
+		\fi
+		\ifdefined\captionsukrainian
+			\if@unicode@engine
+				\addto\captionsukrainian{%
+					\DefTblrTemplate{contfoot-text}{default}{Продовження на наступній сторінці}%
+					\DefTblrTemplate{conthead-text}{default}{(продовження)}%
+				}
+			\else
+				\addto\captionsukrainian{%
+					\DefTblrTemplate{contfoot-text}{default}{\cyr\CYRP\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya\ \cyrn\cyra\ \cyrn\cyra\cyrs\cyrt\cyru\cyrp\cyrn\cyrii\cyrishrt\ \cyrs\cyrt\cyro\cyrr\cyrii\cyrn\cyrc\cyrii}%
+					\DefTblrTemplate{conthead-text}{default}{(\cyr\cyrp\cyrr\cyro\cyrd\cyro\cyrv\cyrzh\cyre\cyrn\cyrn\cyrya)}%
+				}
+			\fi
 		\fi
 	}
 }

--- a/tblr-extras.sty
+++ b/tblr-extras.sty
@@ -54,21 +54,27 @@
 	\SetTblrTemplate{caption-lot}{empty}
 }
 %% ----------------------------------------------------------------------
-%% TblrLibrary babel - Translate contfoot and conthead to current babel
+%% TblrLibrary babel - Translate contfoot and conthead to current babel/polyglossia
 %% language. Supports: ngerman, french and spanish translations.
 \NewTblrLibrary{babel}
 {%
-	\RequirePackage{babel,iflang}
-	\IfLanguagePatterns{spanish}{%
-		\DefTblrTemplate{contfoot-text}{default}{Continúa en la página siguiente}
-		\DefTblrTemplate{conthead-text}{default}{(Continuación)}
-		}{}
-	\IfLanguagePatterns{ngerman}{%
-		\DefTblrTemplate{contfoot-text}{default}{Fortsetzung auf der nächsten Seite}
-		\DefTblrTemplate{conthead-text}{default}{(Fortsetzung)}
-		}{}
-	\IfLanguagePatterns{french}{%
-		\DefTblrTemplate{contfoot-text}{default}{Suite à la page suivante}
-		\DefTblrTemplate{conthead-text}{default}{(Suite)}
-		}{}
+	\AddToHook{begindocument/before}{%
+		\@ifpackageloaded{babel}{}{%
+			\@ifpackageloaded{polyglossia}{}{%
+				\RequirePackage{babel}
+			}
+		}
+		\addto\captionsspanish{%
+			\DefTblrTemplate{contfoot-text}{default}{Continúa en la página siguiente}%
+			\DefTblrTemplate{conthead-text}{default}{(Continuación)}%
+		}
+		\addto\captionsngerman{%
+			\DefTblrTemplate{contfoot-text}{default}{Fortsetzung auf der nächsten Seite}%
+			\DefTblrTemplate{conthead-text}{default}{(Fortsetzung)}%
+		}
+		\addto\captionsfrench{%
+			\DefTblrTemplate{contfoot-text}{default}{Suite à la page suivante}%
+			\DefTblrTemplate{conthead-text}{default}{(Suite)}%
+		}
+	}
 }


### PR DESCRIPTION
I'd like to offer a small enhancement to the babel library: instead of translating strings once, add them to `\captions<language>` hooks. This will help to change them along with the other translatable strings on `\selectlanguage{<language>}`.

Also, I'd like to add translations to Russian and Ukraininan to the list. The code is a bit complicated because users of `pdflatex` still often use 8-bit encodings, hence all these `\cyr<letter>` macros.